### PR TITLE
Fix for disabled SubmitControl objects with no value

### DIFF
--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -2333,7 +2333,13 @@ class SubmitControl(ScalarControl):
         # IE5 defaults SUBMIT value to "Submit Query"; Firebird 0.6 leaves it
         # blank, Konqueror 3.1 defaults to "Submit".  HTML spec. doesn't seem
         # to define this.
-        if self.value is None: self.value = ""
+        if self.value is None:
+            if self.disabled:
+                self.disabled = False
+                self.value = ""
+                self.disabled = True
+            else:
+                self.value = ""
         self.readonly = True
 
     def get_labels(self):


### PR DESCRIPTION
Stop mechanize from crashing with an AttributeError when attempting to select a form a SubmitControl that has no value and is also disabled.

When mechanize encounters a SubmitControl with no value (such as an ImageControl) it attempts to set the value to a blank string. This fails if the control is disabled (mechanize raises an AttributeError). This patch temporarily sets disabled to False in this situation and then immediately resets it to True after the blank string has been assigned to value.
