### PR TITLE
Fixed "element in form"

### DIFF
--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -1370,6 +1370,28 @@ class FileControl(ScalarControl):
                 fh2.write(file_object.read())
             mw2.lastpart()
 
+    def __unicode__(self):
+        name = self.name
+        if name is None: name = u"<None>"
+
+        if not self._upload_data:
+            value = u"<No files added>"
+        else:
+            value = []
+            for file, ctype, filename in self._upload_data:
+                if filename is None:
+                    value.append(u"<Unnamed file>")
+                else:
+                    value.append(filename)
+            value = u", ".join(value)
+
+        info = []
+        if self.disabled: info.append(u"disabled")
+        if self.readonly: info.append(u"readonly")
+        info = u", ".join(info)
+        if info: info = u" (%s)" % info
+
+        return u"<%s(%s=%s)%s>" % (self.__class__.__name__, name, value, info)
     def __str__(self):
         name = self.name
         if name is None: name = "<None>"

--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -3204,7 +3204,7 @@ class HTMLForm:
 
     def _pairs(self):
         """Return sequence of (key, value) pairs suitable for urlencoding."""
-        return [(k, v) for (i, k, v, c_i) in self._pairs_and_controls()]
+        return [(k, v.encode('utf-8') if isinstance(v, unicode) else v) for (i, k, v, c_i) in self._pairs_and_controls()]
 
 
     def _pairs_and_controls(self):

--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -1712,8 +1712,7 @@ class ListControl(Control):
                 continue
             if label is not None:
                 for l in o.get_labels():
-                    if ((compat and l.text == label) or
-                        (not compat and l.text.find(label) > -1)):
+                    if l.text == label:
                         break
                 else:
                     continue

--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -1251,6 +1251,20 @@ class ScalarControl(Control):
 
         return "<%s(%s=%s)%s>" % (self.__class__.__name__, name, value, info)
 
+    def __unicode__(self):
+        name = self.name
+        value = self.value
+        if name is None: name = u"<None>"
+        if value is None: value = u"<None>"
+
+        infos = []
+        if self.disabled: infos.append("disabled")
+        if self.readonly: infos.append("readonly")
+        info = u", ".join(infos)
+        if info: info = u" (%s)" % info
+
+        return u"<%s(%s=%s)%s>" % (self.__class__.__name__, name, value, info)
+
 
 #---------------------------------------------------
 class TextControl(ScalarControl):

--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -1258,8 +1258,8 @@ class ScalarControl(Control):
         if value is None: value = u"<None>"
 
         infos = []
-        if self.disabled: infos.append("disabled")
-        if self.readonly: infos.append("readonly")
+        if self.disabled: infos.append(u"disabled")
+        if self.readonly: infos.append(u"readonly")
         info = u", ".join(infos)
         if info: info = u" (%s)" % info
 
@@ -2810,7 +2810,7 @@ class HTMLForm:
             self.method, self.action, self.enctype)
         rep = [header]
         for control in self.controls:
-            rep.append(u"  %s" % str(control))
+            rep.append(u"  %s" % unicode(control))
         return u"<%s>" % u"\n".join(rep)
 
 #---------------------------------------------------

--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -2767,6 +2767,15 @@ class HTMLForm:
         for control in self.controls:
             rep.append("  %s" % str(control))
         return "<%s>" % "\n".join(rep)
+    
+    def __unicode__(self):
+        header = u"%s%s %s %s" % (
+            (self.name and self.name+" " or ""),
+            self.method, self.action, self.enctype)
+        rep = [header]
+        for control in self.controls:
+            rep.append(u"  %s" % str(control))
+        return u"<%s>" % u"\n".join(rep)
 
 #---------------------------------------------------
 # Form-filling methods.

--- a/mechanize/_form.py
+++ b/mechanize/_form.py
@@ -2775,7 +2775,10 @@ class HTMLForm:
     def __getitem__(self, name):
         return self.find_control(name).value
     def __contains__(self, name):
-        return bool(self.find_control(name))
+        try:
+            return bool(self.find_control(name))
+        except ControlNotFoundError: #I don't know how to do better
+            return False
     def __setitem__(self, name, value):
         control = self.find_control(name)
         try:

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -469,6 +469,7 @@ Rhubarb.
 <select name="foo">
  <option>Hello testers &amp; &blah; users!</option>
  <option></option><option></option>
+ <option>Hello</option>
 </select>
 
 </form>
@@ -489,6 +490,7 @@ Rhubarb.
         self.assertEqual(opt["value"], "Hello testers & &blah; users!")
         self.assertEqual(opt["label"], "Hello testers & &blah; users!")
         self.assertEqual(opt["contents"], "Hello testers & &blah; users!")
+        self.assertEqual(entity_ctl.get(label="Hello").attrs['contents'], 'Hello')
 
     def testButton(self):
         file = StringIO(
@@ -2200,8 +2202,6 @@ class ControlTests(unittest.TestCase):
         c1.set_value_by_label(['Last Option'])  # by second label
         self.assertEqual(c1.get_value_by_label(), ['Third Option'])
         self.assertEqual(c1.value, ['another_value'])
-        c1.set_value_by_label(['irst'])  # by substring
-        self.assertEqual(c1.get_value_by_label(), ['First Option'])
 
 
 class FormTests(unittest.TestCase):
@@ -2678,7 +2678,7 @@ class FormTests(unittest.TestCase):
                     [item.id for item in c.items if item.selected],
                     ["1", "2", None])
                 # disabled items NOT part of 'value by label'
-                c.get(label="Challah").disabled = True
+                c.get(label="Loaf of Challah").disabled = True
                 self.assertEqual(
                     c.get_value_by_label(),
                     ["Loaf of Bread", "Loaf of Bread"])
@@ -2817,7 +2817,7 @@ class FormTests(unittest.TestCase):
                          "Submit")
         self.assertEqual(
             form.find_control(label="Country").get(
-                label="Britain").name, "EU: Great Britain")
+                label="Great Britain").name, "EU: Great Britain")
         self.assertEqual(
             form.find_control(label="Origin").get(
                 label="GB").name, "EU: Great Britain")
@@ -2844,9 +2844,6 @@ class FormTests(unittest.TestCase):
         # Errors may be raised.  This is generally a preferred approach, but is
         # not backwards compatible.
         form.backwards_compat = False
-        self.assertRaises(mechanize.AmbiguityError, c.get, label="Loaf")
-        self.assertRaises(
-            mechanize.AmbiguityError, c.set_value_by_label, ["Loaf"])
         # If items have the same name (value), set_value_by_label will
         # be happy (since it is just setting the value anyway).
         c.set_value_by_label(["Loaf of Bread"])
@@ -2871,9 +2868,6 @@ class FormTests(unittest.TestCase):
         self.assertEqual(
             [i.selected for i in c.get_items(label="Loaf of Challah")],
             [True])
-        self.assertEqual(
-            [i.name for i in c.get_items(label="Loaf")],
-            ["bread", "bread", "bread", "challah"])
         self.assertEqual(
             [i.get_labels()[0].text for i in c.get_items("bread")],
             ["Loaf of Bread", "Loaf of Bread", "Loaf of Bread"])

--- a/test/test_form.py
+++ b/test/test_form.py
@@ -271,6 +271,18 @@ class ParseTests(unittest.TestCase):
             self.assert_(issubclass(mechanize.ParseError,
                                     sgmllib.SGMLParseError))
 
+    def test_in(self):
+        f = StringIO(
+"""<form action="abc">
+<input type="text" name="field1">
+</form>
+""")
+        base_uri = "http://localhost/"
+        forms = mechanize.ParseFile(f, base_uri, backwards_compat=False)
+        form = forms[0]
+        self.assertIn('field1', form);
+        self.assertNotIn('field2', form);
+
     def test_unknown_control(self):
         f = StringIO(
 """<form action="abc">


### PR DESCRIPTION
If form does not contains element, construction `"element" in form` must return False. Now it throws an exception. I tried to fix it, but maybe you know better for to do this
