### PR TITLE
Only escape necessary chars in cookie value.

### DIFF
--- a/mechanize/_clientcookie.py
+++ b/mechanize/_clientcookie.py
@@ -1038,7 +1038,10 @@ class CookieJar:
 
     """
 
-    non_word_re = re.compile(r"\W")
+    # Used to find invalid characters in cookie value.
+    # See http://curl.haxx.se/rfc/cookie_spec.html
+    non_word_re = re.compile(r"[;,\s]")
+
     quote_re = re.compile(r"([\"\\])")
     strict_domain_re = re.compile(r"\.?[^.]*")
     domain_re = re.compile(r"[^.]*")


### PR DESCRIPTION
I ran into the problem this patch fixes when using twill. A server was sending cookie's where the value was an equals (=) character. This caused mechanize to send an escaped cookie back to the server, which it was then unable to understand. So authentication failed.

Thanks!
